### PR TITLE
docs: correct example of conditional chained transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ let results = await mysql.transaction()
   .query('DELETE FROM table WHERE id = ?', [someVar])
   .query((r) => {
     if (r.affectedRows > 0) {
-      ['UPDATE anotherTable SET x = 1 WHERE id = ?', [someVar]]
+      return ['UPDATE anotherTable SET x = 1 WHERE id = ?', [someVar]]
     } else {
       return null
     }


### PR DESCRIPTION
The original example above was not working and standard lint was throwing a warning:
"Expected an assignment or function call and instead saw an expression"