### PR TITLE
Issue #69 - Retry on EPIPE error

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,7 +191,7 @@ module.exports = (params) => {
             client.destroy() // destroy connection on timeout
             resetClient() // reset the client
             reject(err) // reject the promise with the error
-          } else if (err && (/^PROTOCOL_ENQUEUE_AFTER_/.test(err.code) || err.code === 'PROTOCOL_CONNECTION_LOST')) {
+          } else if (err && (/^PROTOCOL_ENQUEUE_AFTER_/.test(err.code) || err.code === 'PROTOCOL_CONNECTION_LOST' || err.code === 'EPIPE')) {
             resetClient() // reset the client
             return resolve(query(...args)) // attempt the query again
           } else if (err) {


### PR DESCRIPTION
Attempts to reuse a connection with MariaDB 10.3.8 sometimes results in an EPIPE error. Retry with a new connection when this happens, just like other dropped-connection errors.