### PR TITLE
Expose escapeId method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -101,6 +101,7 @@ declare namespace serverlessMysql {
     query<T>(...args): Promise<T>
     end(): Promise<void>
     escape(str: string): MySQL.EscapeFunctions
+    escapeId(str: string): MySQL.EscapeFunctions
     quit(): void
     transaction(): Transaction
     getCounter(): number

--- a/index.js
+++ b/index.js
@@ -378,6 +378,7 @@ module.exports = (params) => {
 
   let connCfg = typeof cfg.config === 'object' && !Array.isArray(cfg.config) ? cfg.config : {}
   let escape = MYSQL.escape
+  let escapeId = MYSQL.escapeId
   // Set MySQL configs
   config(connCfg)
 
@@ -389,6 +390,7 @@ module.exports = (params) => {
     query,
     end,
     escape,
+    escapeId,
     quit,
     transaction,
     getCounter,


### PR DESCRIPTION
Sometimes you need to escape query identifiers as well, like the table or column name, when you build up a query in code.
This PR exposes the MySQL.escapeId method for this purpose.