### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,7 +249,7 @@ module.exports = (params) => {
       let results = await query(
         `SELECT COUNT(ID) as total, MAX(time) as max_age
         FROM information_schema.processlist
-        WHERE (user = ? AND @@max_user_connections > 0) OR true`,[_cfg.user])
+        WHERE (user = :user AND @@max_user_connections > 0) OR true`,{user: _cfg.user})
 
       _usedConns = {
         total: results[0].total || 0,


### PR DESCRIPTION
Some new versions of mysql database may throw an error with the old syntax of the line.
something like this:

Error: ER_PARSE_ERROR: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '? AND @@max_user_connections > 0) OR true' at line 3