### PR TITLE
feat: expose `escapeId` and `format` and correct TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -100,7 +100,9 @@ declare namespace serverlessMysql {
     config(config?: MySQL.ConnectionConfig): MySQL.ConnectionConfig
     query<T>(...args): Promise<T>
     end(): Promise<void>
-    escape(str: string): MySQL.EscapeFunctions
+    escape: MySQL.EscapeFunctions['escape'],
+    escapeId: MySQL.EscapeFunctions['escapeId'],
+    format: MySQL.EscapeFunctions['format'],
     quit(): void
     transaction(): Transaction
     getCounter(): number

--- a/index.js
+++ b/index.js
@@ -378,6 +378,9 @@ module.exports = (params) => {
 
   let connCfg = typeof cfg.config === 'object' && !Array.isArray(cfg.config) ? cfg.config : {}
   let escape = MYSQL.escape
+  let escapeId = MYSQL.escapeId
+  let format = MYSQL.format
+
   // Set MySQL configs
   config(connCfg)
 
@@ -389,6 +392,8 @@ module.exports = (params) => {
     query,
     end,
     escape,
+    escapeId,
+    format,
     quit,
     transaction,
     getCounter,


### PR DESCRIPTION
Can now use `escapeId` and `format` functions on the `mysql` object.

The previous type of the mysql.escape function was wrong - should be a function returning a string (not a function returning {escape,escapeId,format}.  Corrected this and used the same scheme for the new functions