### PR TITLE
feat: add ECONNRESET to retry condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,7 +194,8 @@ module.exports = (params) => {
           } else if (
             err && (/^PROTOCOL_ENQUEUE_AFTER_/.test(err.code) 
             || err.code === 'PROTOCOL_CONNECTION_LOST' 
-            || err.code === 'EPIPE')
+            || err.code === 'EPIPE'
+            || err.code === 'ECONNRESET')
           ) {
             resetClient() // reset the client
             return resolve(query(...args)) // attempt the query again


### PR DESCRIPTION
ECONNRESET happens when the sql connection is closed from the server side. This will now retry the query with a new connection when this error is thrown.

Closes #69 