### PR TITLE
feat: add support for a connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,17 @@ let value = connection.escape('Some value to be escaped')
 ```
 
 ## Configuration Options
+
+There are two ways to provide a configuration.
+
+The one way is using a connection string at initialization time.
+
+```javascript
+const mysql = require('serverless-mysql')(`mysql://${process.env.USERNAME}:${process.env.PASSWORD}@${process.env.ENDPOINT}:${process.env.PORT}/${process.env.DATABASE}`)
+```
+
+The other way is to pass in the options defined in the below table.
+
 Below is a table containing all of the possible configuration options for `serverless-mysql`. Additional details are provided throughout the documentation.
 
 | Property | Type | Description | Default |

--- a/index.d.ts
+++ b/index.d.ts
@@ -110,5 +110,5 @@ declare namespace serverlessMysql {
   }
 }
 
-declare function serverlessMysql (cfg?: serverlessMysql.Config): serverlessMysql.ServerlessMysql
+declare function serverlessMysql (cfg?: string | serverlessMysql.Config): serverlessMysql.ServerlessMysql
 export = serverlessMysql

--- a/index.d.ts
+++ b/index.d.ts
@@ -97,7 +97,7 @@ declare namespace serverlessMysql {
 
   export type ServerlessMysql = {
     connect(wait?: number): Promise<void>
-    config(config?: MySQL.ConnectionConfig): MySQL.ConnectionConfig
+    config(config?: string | MySQL.ConnectionConfig): MySQL.ConnectionConfig
     query<T>(...args): Promise<T>
     end(): Promise<void>
     escape(str: string): MySQL.EscapeFunctions

--- a/index.js
+++ b/index.js
@@ -52,7 +52,12 @@ module.exports = (params) => {
   const resetRetries = () => retries = 0
   const getErrorCount = () => errors
   const getConfig = () => _cfg
-  const config = (args) => Object.assign(_cfg,args)
+  const config = (args) => {
+    if (typeof args === 'string') {
+      return Object.assign(_cfg,uriToConnectionConfig(args))
+    } 
+    return Object.assign(_cfg,args)
+  }
   const delay = ms => new PromiseLibrary(res => setTimeout(res, ms))
   const randRange = (min,max) => Math.floor(Math.random() * (max - min + 1)) + min
   const fullJitter = () => randRange(0, Math.min(cap, base * 2 ** retries))
@@ -410,7 +415,7 @@ module.exports = (params) => {
   if (typeof cfg.config === 'object' && !Array.isArray(cfg.config)) {
     connCfg = cfg.config
   } else if (typeof params === 'string') {
-    connCfg = uriToConnectionConfig(params)
+    connCfg = params
   }
 
   let escape = MYSQL.escape

--- a/test/connection-config.spec.js
+++ b/test/connection-config.spec.js
@@ -1,0 +1,55 @@
+const assert = require("assert");
+
+const mysql = require("../index");
+
+describe("Test a connection config", () => {
+  it("Should get a valid connection config when a config is passed in", () => {
+    const configs = [
+      mysql({
+        config: {
+          host: "localhost",
+          database: "database",
+          user: "user",
+          password: "password",
+        },
+      }).getConfig(),
+      mysql().config({
+        host: "localhost",
+        database: "database",
+        user: "user",
+        password: "password",
+      }),
+    ];
+
+    configs.forEach((config) => {
+      assert.deepEqual(config, {
+        host: "localhost",
+        database: "database",
+        user: "user",
+        password: "password",
+      });
+    });
+  });
+
+  it("Should get a valid connection config when a connection string is passed in", () => {
+    const configs = [
+      mysql("mysql://user:password@localhost:3306/database").getConfig(),
+      mysql().config("mysql://user:password@localhost:3306/database"),
+    ];
+
+    configs.forEach((config) => {
+      assert.deepEqual(config, {
+        host: "localhost",
+        database: "database",
+        user: "user",
+        password: "password",
+        port: "3306",
+      });
+    });
+  });
+
+  it("Should throw an exception when an invalid connection string is passed in", () => {
+    assert.throws(() => mysql("mysql://:3306/database").getConfig());
+    assert.throws(() => mysql("mysql://:3306").getConfig());
+  });
+});


### PR DESCRIPTION
Adding support for a connection string option.

Related to the issue: #115 