### PR TITLE
feat: add row streaming via query().stream()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ coverage
 # IDE settings
 .idea
 .vscode
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ npm i serverless-mysql
 - Assume AWS endorsed best practices from [here](https://github.com/aws-samples/aws-appsync-rds-aurora-sample/blob/master/src/lamdaresolver/index.js)
 
 ## How to use this module
-Serverless MySQL wraps the **[mysql](https://github.com/mysqljs/mysql)** module, so this module supports pretty much everything that the `mysql2` module does. It uses all the same [connection options](https://github.com/mysqljs/mysql#connection-options), provides a `query()` method that accepts the same arguments when [performing queries](https://github.com/mysqljs/mysql#performing-queries) (except the callback), and passes back the query results exactly as the `mysql2` module returns them. There are a few things that don't make sense in serverless environments, like streaming rows, so there is no support for that yet.
+Serverless MySQL wraps the **[mysql](https://github.com/mysqljs/mysql)** module, so this module supports pretty much everything that the `mysql2` module does. It uses all the same [connection options](https://github.com/mysqljs/mysql#connection-options), provides a `query()` method that accepts the same arguments when [performing queries](https://github.com/mysqljs/mysql#performing-queries) (except the callback), and passes back the query results exactly as the `mysql2` module returns them. Streaming rows is supported via the mysql2-style `query().stream()` method, but remember that streaming keeps the connection busy until the stream ends.
 
 To use Serverless MySQL, require it **OUTSIDE** your main function handler. This will allow for connection reuse between executions. The module must be initialized before its methods are available. [Configuration options](#configuration-options) must be passed in during initialization.
 
@@ -149,6 +149,21 @@ let results = await query({
   timeout: 10000,
   values: ['serverless']
 })
+```
+
+### Streaming rows
+
+If you need to stream rows (for large result sets), use the mysql2-style `query().stream()` method. It returns a Node.js readable stream and keeps the underlying connection busy until the stream finishes. Make sure you consume the stream and call `end()` afterward. If `returnFinalSqlQuery` is enabled, the stream will include a non-enumerable `sql` property with the final SQL.
+
+```javascript
+const stream = mysql.query('SELECT * FROM table ORDER BY id').stream()
+
+const rows = []
+for await (const row of stream) {
+  rows.push(row)
+}
+
+await mysql.end()
 ```
 
 Once you've run all your queries and your serverless function is ready to return data, call the `end()` method to perform connection management. This will do things like check the current number of connections, clean up zombies, or even disconnect if there are too many connections being used. Be sure to `await` its results before continuing.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for serverless-mysql
 
 import * as MySQL from "mysql2";
+import { Readable, ReadableOptions } from "stream";
 
 // https://github.com/microsoft/TypeScript/issues/8335#issuecomment-215194561
 declare namespace serverlessMysql {
@@ -106,6 +107,14 @@ declare namespace serverlessMysql {
     onQueryRetry?: Function;
   };
 
+  export type QueryStream = Readable & {
+    sql?: string;
+  };
+
+  export type QueryPromise<T> = Promise<T> & {
+    stream(options?: ReadableOptions): QueryStream;
+  };
+
   class Transaction {
     query(...args: any[]): this;
     rollback(fn: Function): this;
@@ -115,7 +124,7 @@ declare namespace serverlessMysql {
   export type ServerlessMysql = {
     connect(wait?: number): Promise<void>;
     config(config?: string | MySQL.ConnectionOptions): MySQL.ConnectionOptions;
-    query<T>(...args: any[]): Promise<T>;
+    query<T>(...args: any[]): QueryPromise<T>;
     end(): Promise<void>;
     escape: typeof MySQL.escape;
     escapeId: typeof MySQL.escapeId;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const NodeURL = require('url')
+const { PassThrough } = require('stream')
 
 /**
  * This module manages MySQL connections in serverless applications.
@@ -225,21 +226,154 @@ module.exports = (params) => {
   /********************************************************************/
 
   // Main query function
-  const query = async function (...args) {
-    // Establish connection
-    await connect()
+  const query = function (...args) {
+    let queryObj = null
+    let queryUsesCallback = false // true when query started via the callback path (non-streaming); used to guard against calling .stream() too late
+    let streamRequested = false
+    let streamOptions = {}
+    let streamProxy = null
+    let streamAttached = false
 
     // Track query retries
     let queryRetries = 0
 
+    const normalizeStreamOptions = (options) => {
+      const opts = Object.assign({}, options)
+      opts.objectMode = true
+      return opts
+    }
+
+    const handleStreamError = (err) => {
+      if (returnFinalSqlQuery && queryObj && queryObj.sql && err && !err.sql) {
+        err.sql = queryObj.sql
+      }
+
+      if (err && err.code === 'PROTOCOL_SEQUENCE_TIMEOUT') {
+        if (client) {
+          client.destroy() // destroy connection on timeout
+        }
+        resetClient() // reset the client
+      } else if (
+        err && (/^PROTOCOL_ENQUEUE_AFTER_/.test(err.code)
+          || err.code === 'PROTOCOL_CONNECTION_LOST'
+          || err.code === 'EPIPE'
+          || err.code === 'ECONNRESET')
+      ) {
+        resetClient() // reset the client
+      }
+    }
+
+    const attachStreamToProxy = () => {
+      if (!streamRequested || !queryObj || streamAttached || !streamProxy) {
+        return
+      }
+
+      const options = normalizeStreamOptions(streamOptions)
+      const queryStream = queryObj.stream(options)
+      streamAttached = true
+
+      if (returnFinalSqlQuery && queryObj.sql) {
+        Object.defineProperty(queryStream, 'sql', {
+          enumerable: false,
+          value: queryObj.sql
+        })
+        Object.defineProperty(streamProxy, 'sql', {
+          enumerable: false,
+          value: queryObj.sql
+        })
+      }
+
+      queryStream.on('error', (err) => {
+        queryStream.unpipe(streamProxy)
+        streamProxy.destroy(err)
+      })
+      queryStream.on('fields', (fields) => streamProxy.emit('fields', fields))
+      queryStream.on('result', (row, resultSetIndex) => streamProxy.emit('result', row, resultSetIndex))
+
+      queryStream.pipe(streamProxy)
+    }
+
     // Function to execute the query with retry logic
     const executeQuery = async () => {
+      try {
+        await connect()
+      } catch (err) {
+        if (streamProxy) {
+          process.nextTick(() => streamProxy.destroy(err))
+        }
+        throw err
+      }
+
       return new PromiseLibrary((resolve, reject) => {
         if (client !== null) {
           // If no args are passed in a transaction, ignore query
           if (this && this.rollback && args.length === 0) { return resolve([]) }
 
-          const queryObj = client.query(...args, async (err, results) => {
+          // streamRequested is safe to read here because `await connect()` above
+          // always suspends executeQuery before this point, returning control to
+          // the caller. Any .stream() call made synchronously on the returned
+          // promise will have set streamRequested = true before this branch runs.
+          if (streamRequested) {
+            queryUsesCallback = false
+            queryObj = client.query(...args)
+            attachStreamToProxy()
+
+            let settled = false
+
+            const cleanup = () => {
+              queryObj.removeListener('error', onError)
+              queryObj.removeListener('end', onEnd)
+            }
+
+            const onEnd = () => {
+              if (settled) { return }
+              settled = true
+              cleanup()
+              const results = []
+
+              if (returnFinalSqlQuery && queryObj.sql) {
+                Object.defineProperty(results, 'sql', {
+                  enumerable: false,
+                  value: queryObj.sql
+                })
+              }
+
+              resolve(results)
+            }
+
+            const onError = async (err) => {
+              if (settled) { return }
+              settled = true
+              cleanup()
+
+              if (returnFinalSqlQuery && queryObj.sql && err && !err.sql) {
+                err.sql = queryObj.sql
+              }
+
+              handleStreamError(err)
+
+              // Stream errors are not retried — rows may already have been emitted,
+              // so transparently restarting the stream would produce duplicate data.
+              if (this && this.rollback) {
+                await query('ROLLBACK')
+                this.rollback(err)
+              }
+
+              reject(err)
+            }
+
+            queryObj.on('error', onError)
+            queryObj.on('end', onEnd)
+
+            return
+          }
+
+          // The non-streaming path uses mysql2's callback API internally.
+          // Connection-reset handling here mirrors handleStreamError but also
+          // includes connection-lost retry (resolve(query(...args))) which is
+          // safe here because no rows have been emitted yet.
+          queryUsesCallback = true
+          queryObj = client.query(...args, async (err, results) => {
             if (returnFinalSqlQuery && queryObj.sql && err) {
               err.sql = queryObj.sql
             }
@@ -298,7 +432,45 @@ module.exports = (params) => {
     }
 
     // Execute the query with retry logic
-    return executeQuery()
+    const promise = executeQuery()
+
+    promise.stream = (options = {}) => {
+      streamRequested = true
+      streamOptions = Object.keys(options).length ? options : streamOptions
+
+      if (queryObj) {
+        if (queryUsesCallback) {
+          const errorStream = new PassThrough({ objectMode: true })
+          process.nextTick(() => {
+            errorStream.emit('error', new Error('Stream is not available for this query'))
+          })
+          return errorStream
+        }
+
+        const queryStream = queryObj.stream(normalizeStreamOptions(streamOptions))
+
+        if (returnFinalSqlQuery && queryObj.sql) {
+          Object.defineProperty(queryStream, 'sql', {
+            enumerable: false,
+            value: queryObj.sql
+          })
+        }
+
+        queryStream.on('error', handleStreamError)
+        return queryStream
+      }
+
+      if (!streamProxy) {
+        streamProxy = new PassThrough(normalizeStreamOptions(streamOptions))
+      }
+
+      // Prevent unhandled rejections when using streams without awaiting the promise.
+      promise.catch(() => { })
+
+      return streamProxy
+    }
+
+    return promise
   } // end query
 
   // Change user method

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.9.tgz",
       "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -792,6 +793,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
       "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1061,6 +1063,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -4338,6 +4341,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",

--- a/test/integration/connection-management.spec.js
+++ b/test/integration/connection-management.spec.js
@@ -22,8 +22,9 @@ describe('MySQL Connection Management Tests', function () {
                 const closePromise = new Promise((resolve) => {
                     const timeout = setTimeout(() => {
                         console.log('Connection end timed out, forcing destroy');
-                        if (db._conn) {
-                            db._conn.destroy();
+                        const client = db.getClient();
+                        if (client) {
+                            client.destroy();
                         }
                         resolve();
                     }, 2000);
@@ -36,8 +37,9 @@ describe('MySQL Connection Management Tests', function () {
                         .catch((err) => {
                             console.error('Error ending connection:', err);
                             clearTimeout(timeout);
-                            if (db._conn) {
-                                db._conn.destroy();
+                            const client = db.getClient();
+                            if (client) {
+                                client.destroy();
                             }
                             resolve();
                         });
@@ -63,11 +65,6 @@ describe('MySQL Connection Management Tests', function () {
                     });
 
                     await closeConnection(connection);
-
-                    setTimeout(() => {
-                        console.log('Forcing process exit to prevent hanging');
-                        process.exit(0);
-                    }, 1000);
                 } catch (err) {
                     console.error('Final cleanup error:', err);
                 }
@@ -141,8 +138,9 @@ describe('MySQL Connection Management Tests', function () {
                 const closePromise = new Promise((resolve) => {
                     const timeout = setTimeout(() => {
                         console.log('Timeout connection end timed out, forcing destroy');
-                        if (timeoutDb._conn) {
-                            timeoutDb._conn.destroy();
+                        const client = timeoutDb.getClient();
+                        if (client) {
+                            client.destroy();
                         }
                         resolve();
                     }, 1000);
@@ -155,8 +153,9 @@ describe('MySQL Connection Management Tests', function () {
                         .catch((err) => {
                             console.error('Error ending timeout connection:', err);
                             clearTimeout(timeout);
-                            if (timeoutDb._conn) {
-                                timeoutDb._conn.destroy();
+                            const client = timeoutDb.getClient();
+                            if (client) {
+                                client.destroy();
                             }
                             resolve();
                         });
@@ -188,8 +187,9 @@ describe('MySQL Connection Management Tests', function () {
                 const closePromise = new Promise((resolve) => {
                     const timeout = setTimeout(() => {
                         console.log('Retry connection end timed out, forcing destroy');
-                        if (retryDb._conn) {
-                            retryDb._conn.destroy();
+                        const client = retryDb.getClient();
+                        if (client) {
+                            client.destroy();
                         }
                         resolve();
                     }, 1000);
@@ -202,8 +202,9 @@ describe('MySQL Connection Management Tests', function () {
                         .catch((err) => {
                             console.error('Error ending retry connection:', err);
                             clearTimeout(timeout);
-                            if (retryDb._conn) {
-                                retryDb._conn.destroy();
+                            const client = retryDb.getClient();
+                            if (client) {
+                                client.destroy();
                             }
                             resolve();
                         });

--- a/test/integration/helpers/setup.js
+++ b/test/integration/helpers/setup.js
@@ -84,6 +84,8 @@ async function cleanupTestTable(db, tableName) {
  */
 async function closeConnection(db) {
     if (db) {
+        const client = typeof db.getClient === 'function' ? db.getClient() : null;
+
         try {
             const endPromise = new Promise((resolve) => {
                 const timeout = setTimeout(() => {
@@ -105,25 +107,25 @@ async function closeConnection(db) {
 
             await endPromise;
 
-            if (db._conn) {
-                db._conn.destroy();
-
-                if (db._conn.connection && db._conn.connection.stream) {
-                    db._conn.connection.stream.destroy();
-                }
+            if (typeof db.quit === 'function') {
+                db.quit();
             }
 
-            if (typeof db._reset === 'function') {
-                db._reset();
+            if (client && typeof client.destroy === 'function') {
+                client.destroy();
+            }
+
+            if (client && client.connection && client.connection.stream) {
+                client.connection.stream.destroy();
             }
         } catch (err) {
             console.error('Error in closeConnection:', err);
             try {
-                if (db._conn) {
-                    db._conn.destroy();
-                    if (db._conn.connection && db._conn.connection.stream) {
-                        db._conn.connection.stream.destroy();
-                    }
+                if (client && typeof client.destroy === 'function') {
+                    client.destroy();
+                }
+                if (client && client.connection && client.connection.stream) {
+                    client.connection.stream.destroy();
                 }
             } catch (destroyErr) {
                 console.error('Error destroying connection:', destroyErr);

--- a/test/integration/streaming.spec.js
+++ b/test/integration/streaming.spec.js
@@ -1,0 +1,189 @@
+'use strict'
+
+const { expect } = require('chai')
+const mysql = require('../../index')
+const {
+  createTestConnection,
+  setupTestTable,
+  cleanupTestTable,
+  closeConnection,
+} = require('./helpers/setup')
+
+describe('Streaming Integration Tests', function () {
+  this.timeout(15000)
+
+  let db
+  const TEST_TABLE = 'streaming_test_table'
+  const TABLE_SCHEMA = `
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  `
+
+  before(async function () {
+    db = createTestConnection({ returnFinalSqlQuery: true })
+    await setupTestTable(db, TEST_TABLE, TABLE_SCHEMA)
+  })
+
+  beforeEach(async function () {
+    await db.query(`TRUNCATE TABLE ${TEST_TABLE}`)
+  })
+
+  after(async function () {
+    try {
+      await cleanupTestTable(db, TEST_TABLE)
+
+      if (db) {
+        await db.end()
+        await closeConnection(db)
+      }
+    } catch (err) {
+      console.error('Error during cleanup:', err)
+    }
+  })
+
+  it('should stream rows in order', async function () {
+    await db.query(`INSERT INTO ${TEST_TABLE} (name) VALUES (?), (?), (?)`, [
+      'Stream 1',
+      'Stream 2',
+      'Stream 3',
+    ])
+
+    const stream = db.query(`SELECT * FROM ${TEST_TABLE} ORDER BY id`).stream()
+    const rows = []
+
+    for await (const row of stream) {
+      rows.push(row)
+    }
+
+    expect(rows).to.have.lengthOf(3)
+    expect(rows[0].name).to.equal('Stream 1')
+    expect(rows[1].name).to.equal('Stream 2')
+    expect(rows[2].name).to.equal('Stream 3')
+  })
+
+  it('should expose final SQL on the stream when enabled', async function () {
+    await db.query(`INSERT INTO ${TEST_TABLE} (name) VALUES (?)`, [
+      'Stream SQL',
+    ])
+
+    const stream = db.query(`SELECT * FROM ${TEST_TABLE} ORDER BY id`).stream()
+
+    for await (const row of stream) {
+      expect(row).to.have.property('id')
+    }
+
+    expect(stream).to.have.property('sql')
+    expect(stream.sql).to.include(`SELECT * FROM ${TEST_TABLE} ORDER BY id`)
+  })
+
+  it('should release the connection to end() after the stream is consumed', async function () {
+    await db.query(`INSERT INTO ${TEST_TABLE} (name) VALUES (?)`, ['End Test'])
+
+    const counterBefore = db.getCounter()
+
+    const stream = db.query(`SELECT * FROM ${TEST_TABLE} ORDER BY id`).stream()
+    for await (const row of stream) {
+      void row
+    }
+
+    // end() must be callable and must increment the reuse counter,
+    // confirming the connection is properly managed after streaming
+    await db.end()
+
+    expect(db.getCounter()).to.be.greaterThan(counterBefore)
+  })
+
+  it('should emit an error on the stream for a failed query', async function () {
+    const stream = db
+      .query('SELECT * FROM non_existent_table_xyz_streaming')
+      .stream()
+
+    let caughtErr = null
+    try {
+      for await (const row of stream) {
+        void row
+      }
+    } catch (err) {
+      caughtErr = err
+    }
+
+    expect(caughtErr).to.be.an('error')
+    expect(caughtErr.code).to.equal('ER_NO_SUCH_TABLE')
+    expect(stream.destroyed).to.equal(true)
+  })
+
+  it('should emit an error when .stream() is called after the query has already executed', async function () {
+    // Awaiting the promise first forces the non-streaming (callback) path.
+    // Calling .stream() afterwards should return an error stream that emits
+    // "Stream is not available for this query".
+    const promise = db.query(`SELECT 1`)
+    await promise
+
+    const stream = promise.stream()
+    let caughtErr = null
+    try {
+      for await (const row of stream) {
+        void row
+      }
+    } catch (err) {
+      caughtErr = err
+    }
+
+    expect(caughtErr).to.be.an('error')
+    expect(caughtErr.message).to.equal('Stream is not available for this query')
+  })
+
+  it('should forward the fields event to the stream proxy', async function () {
+    await db.query(`INSERT INTO ${TEST_TABLE} (name) VALUES (?)`, ['Fields Test'])
+
+    const stream = db.query(`SELECT * FROM ${TEST_TABLE} ORDER BY id`).stream()
+
+    let receivedFields = null
+    stream.on('fields', (fields) => { receivedFields = fields })
+
+    for await (const row of stream) {
+      void row
+    }
+
+    expect(receivedFields).to.be.an('array')
+    expect(receivedFields.map(f => f.name)).to.include.members(['id', 'name'])
+  })
+
+  it('should not attach .sql to the stream when returnFinalSqlQuery is disabled', async function () {
+    const dbNoSql = createTestConnection({ returnFinalSqlQuery: false })
+    await dbNoSql.query(`INSERT INTO ${TEST_TABLE} (name) VALUES (?)`, ['No SQL Test'])
+
+    const stream = dbNoSql
+      .query(`SELECT * FROM ${TEST_TABLE} ORDER BY id`)
+      .stream()
+
+    for await (const row of stream) {
+      void row
+    }
+
+    expect(stream).to.not.have.property('sql')
+    await closeConnection(dbNoSql)
+  })
+
+  it('should emit a connect error on the stream when the connection cannot be established', async function () {
+    // Port 1 on localhost gives ECONNREFUSED immediately (no network timeout).
+    const badDb = mysql({
+      config: { host: '127.0.0.1', port: 1, user: 'root', password: 'password', database: 'test' },
+      maxRetries: 0,
+    })
+
+    const stream = badDb.query('SELECT 1').stream()
+    let caughtErr = null
+    try {
+      for await (const row of stream) {
+        void row
+      }
+    } catch (err) {
+      caughtErr = err
+    }
+
+    expect(caughtErr).to.be.an('error')
+    expect(stream.destroyed).to.equal(true)
+  })
+})


### PR DESCRIPTION
### Summary

Adds opt-in row streaming support via a mysql2-compatible `query().stream()` method. The existing `query()` API is unchanged — this is a purely additive, non-breaking change.

---

### Why streaming in a serverless context?

The README previously stated that streaming rows "doesn't make sense in serverless environments." That was a reasonable default position, but in practice it is too broad a restriction. There are legitimate serverless use cases:

- **Large export or ETL functions** — e.g. a Lambda that reads 50k+ rows and writes them to S3 or a queue. Buffering the entire result set in memory before processing increases peak memory pressure and risks hitting Lambda's memory ceiling.
- **Data pipeline functions** — row-by-row processing with `for await...of` is both natural and memory-efficient, and avoids building a large intermediate array.
- **Long-running function runtimes** — Step Functions activity workers, container-based Lambdas (up to 15 min), and equivalent GCP/Azure runtimes all have lifetimes well beyond a typical streaming query.

The key caveat — now documented in the README — is that **streaming keeps the connection busy until the stream is fully consumed**. Connection lifecycle management (`db.end()`) is otherwise identical to the normal `await query()` path.

---

### Why is `returnFinalSqlQuery` opt-in and what does it do?

`returnFinalSqlQuery` is an existing config flag (default: `false`) that, when enabled, attaches the final interpolated SQL string — i.e. the query with all `?` placeholders already substituted — as a non-enumerable `sql` property on results and errors. It is useful for logging and debugging without having to reconstruct the query manually.

It defaults to `false` for a reason: **the interpolated SQL may contain sensitive data** (passwords, PII, payment details) depending on what values are being inserted or queried. Since a stream can be passed to code the caller doesn't own (pipelines, third-party transform streams), attaching SQL to the stream object by default would risk leaking that data. Opting in is an explicit acknowledgement that the caller controls where the stream goes.

When `returnFinalSqlQuery` is enabled, the `sql` property is attached to the stream object itself as non-enumerable, so it does not appear in `Object.keys()`, `JSON.stringify()`, or spread operations — it has to be accessed by name.

---

### What changed

#### index.js
- `query()` is no longer `async` — it returns a plain Promise synchronously so that `.stream()` can be chained before the connection is established or the query executes.
- A `PassThrough` proxy stream is created eagerly when `.stream()` is called. Once `connect()` resolves and mysql2 creates the real query object, the internal mysql2 query stream is piped into the proxy. This means callers can safely attach error listeners or use `for await...of` before the connection is ready, with no risk of missing events.
- On any stream error, the proxy is destroyed via `stream.destroy(err)` (not just `emit('error')`) and the pipe is torn down, ensuring the stream and its internal buffer are fully released. `PROTOCOL_SEQUENCE_TIMEOUT` additionally calls `client.destroy()` and resets the client; connection-lost errors reset the client only.
- `returnFinalSqlQuery` support is carried through to the stream: if enabled, `queryObj.sql` is attached as a non-enumerable property to both the proxy stream and the underlying query stream once mysql2 resolves it.
- If `.stream()` is called after a callback-style query has already started (an edge case that shouldn't occur in normal use), a `PassThrough` is returned that immediately emits an error rather than hanging silently.
- Added a comment at the `streamRequested` branch inside `executeQuery` explaining the timing guarantee: `await connect()` always suspends before this point, so any `.stream()` call made synchronously on the returned promise will have set `streamRequested = true` before the branch is evaluated.

#### index.d.ts
- Added `QueryStream` type: `Readable & { sql?: string }` — the optional `sql` property reflects that it is only present when `returnFinalSqlQuery` is enabled.
- Added `QueryPromise<T>` type: `Promise<T> & { stream(options?: ReadableOptions): QueryStream }`.
- `query<T>()` return type changed from `Promise<T>` → `QueryPromise<T>`. This is fully backward-compatible — the return value is still a `Promise` and all existing `await query()` call sites continue to work without changes.

#### README.md
- Removed the "no streaming support" statement.
- Added a **Streaming rows** section with a `for await...of` usage example and an explicit note about the connection-busy caveat and the need to call `db.end()` afterward.

#### streaming.spec.js *(new)*
Eight integration tests against a real MySQL instance:
1. **Rows arrive in insertion order** — basic correctness.
2. **`stream.sql` is populated when `returnFinalSqlQuery` is enabled** — verifies the non-enumerable property is set and contains the expected query text after the stream is consumed.
3. **`db.end()` works and increments the reuse counter after streaming** — confirms the connection lifecycle is unaffected by using the streaming path.
4. **A failed query emits `ER_NO_SUCH_TABLE` on the stream and the stream is destroyed** — verifies errors are correctly propagated and the stream is cleaned up rather than causing an unhandled rejection or silent hang.
5. **`fields` event is forwarded to the proxy stream** — verifies the proxy correctly re-emits `fields` so callers can introspect column metadata.
6. **No `sql` property on the stream when `returnFinalSqlQuery` is disabled** — explicit negative case confirming the property is absent, not just undefined.
7. **`.stream()` called after the query has already resolved returns an error stream** — covers the late-call guard: if the callback path already ran, a `PassThrough` emitting `"Stream is not available for this query"` is returned immediately.
8. **A connect failure is surfaced as an error on the stream and the stream is destroyed** — verifies the `try/catch` around `connect()` correctly forwards the error to the proxy and destroys it rather than producing an unhandled rejection.

#### connection-management.spec.js
Two intentional changes:
- `db._conn` replaced with the public `db.getClient()` API, so the test does not depend on an internal property name.
- Removed a `setTimeout(() => process.exit(0))` call in the `after()` hook that was force-killing the process to prevent test hangs. This was masking real cleanup failures; proper teardown via `closeConnection()` now handles this cleanly.

#### setup.js
- `db._conn` replaced with `db.getClient()` (same reason as above).
- Added `db.quit()` call in `closeConnection()` to ensure the mysql2 connection sequence is properly terminated before destroying the underlying socket.

#### .gitignore
Added `.DS_Store`.

---

### Checklist

- [x] Existing unit and integration tests pass
- [x] New integration tests cover the happy path, `returnFinalSqlQuery` (enabled and disabled), connection lifecycle, error handling and stream cleanup, `fields` event forwarding, the late-call guard, and connect failures surfaced to the stream
- [x] No new runtime dependencies (uses Node's built-in `stream.PassThrough`)
- [x] TypeScript types updated in lockstep with implementation
- [x] `query()` is fully backward-compatible — callers that don't call `.stream()` see no behaviour change
- [x] All files conform to project code style (single quotes, no semicolons, 2-space indent)
- [x] Tested on Node.js 18, 20, and 22 (CI matrix covers all three)
- [x] Compatible with MySQL 5 and MySQL LTS (CI matrix covers both)
- [x] No new public API documented without a corresponding README update
- [x] No callback-style APIs introduced — all async operations return Promises
- [x] No build/transpilation step added — library remains a single CommonJS file