### PR TITLE
feat(benchmark): reproducible LocalStack Lambda benchmark suite

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ coverage
 node_modules
 test
 scripts
+benchmark

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: "Release Benchmarks"
+
+# On every tagged release (e.g. v2.2.0), run the benchmark suite and commit the
+# refreshed results back to master so the README always reflects the latest numbers.
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run benchmark and update README
+        run: npm run benchmark:readme
+
+      - name: Commit refreshed benchmark results
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- README.md benchmark/results.md benchmark/results.json; then
+            echo "No benchmark changes to commit."
+            exit 0
+          fi
+          git add README.md benchmark/results.md benchmark/results.json
+          git commit -m "chore(benchmark): refresh results for ${GITHUB_REF_NAME} [skip ci]"
+          git push origin HEAD:master

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ coverage
 # IDE settings
 .idea
 .vscode
+
+# Benchmark build artifacts (results.json / results.md ARE committed)
+benchmark/lambda/function.zip
+benchmark/lambda/package-lock.json

--- a/README.md
+++ b/README.md
@@ -414,6 +414,31 @@ From the graph below you can see that the average response time was **41 ms** (m
 
 Other tests that use larger configurations were extremely successful too, but I'd appreciate other independent tests to verify my assumptions.
 
+### Benchmarks
+
+The [`benchmark/`](benchmark/) directory contains a reproducible benchmark that compares `serverless-mysql` against the naive connection-per-call approach using a real Lambda fleet (LocalStack) against a connection-constrained MySQL. The table below is refreshed automatically on every release.
+
+<!-- BENCHMARK:START -->
+
+_Generated: 2026-06-27T16:37:55.159Z · MySQL `max_connections=30` · query `SELECT SLEEP(0.02)` · 8s per level · Node v20.19.5_
+
+| Driver | Concurrency | Success rate | Throughput (inv/s) | p50 (ms) | p95 (ms) | p99 (ms) | Peak conns | Failures |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| serverless-mysql (managed) | 5 | 100% | 126.6 | 22 | 23 | 24 | 6 | — |
+| raw mysql2 (per-call) | 5 | 100% | 125.9 | 23 | 25 | 30 | 11 | — |
+| serverless-mysql (managed) | 10 | 100% | 238.2 | 22 | 22 | 24 | 11 | — |
+| raw mysql2 (per-call) | 10 | 100% | 233.9 | 22 | 25 | 30 | 21 | — |
+| serverless-mysql (managed) | 20 | 100% | 170.5 | 22 | 24 | 35 | 21 | — |
+| raw mysql2 (per-call) | 20 | 98.7% | 155.8 | 23 | 28 | 73 | 31 | ER_CON_COUNT_ERROR×17 |
+| serverless-mysql (managed) | 30 | 100% | 157.3 | 22 | 26 | 40 | 27 | — |
+| raw mysql2 (per-call) | 30 | 97.4% | 129.2 | 23 | 29 | 54 | 31 | ER_CON_COUNT_ERROR×29 |
+
+See [`benchmark/`](benchmark/) for the harness and methodology. Numbers come from a
+single host (LocalStack Lambda + MySQL in Docker) and illustrate the connection-management
+mechanism and relative behavior, not absolute production SLAs.
+
+<!-- BENCHMARK:END -->
+
 ## Contributions
 Contributions, ideas and bug reports are welcome and greatly appreciated. Please add [issues](https://github.com/jeremydaly/serverless-mysql/issues) for suggestions and bug reports or create a pull request.
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,72 @@
+# serverless-mysql Benchmarks
+
+A reproducible benchmark that compares **serverless-mysql** against the naive
+**connection-per-call** approach it replaces, using a *real Lambda fleet* (via
+[LocalStack](https://localstack.cloud/)) against a connection-constrained MySQL.
+It provides a before/after that anyone can run.
+
+## What it measures
+
+For each concurrency level, a fixed-duration concurrent workload is fired at each
+driver while the database's open-connection count is sampled. We report:
+
+- **Success rate** — including the breakdown of failures by error code
+  (`ER_CON_COUNT_ERROR` when the connection cap is exceeded).
+- **Peak open connections** — sampled from `SHOW STATUS LIKE 'Threads_connected'`.
+- **Throughput & latency** — invocations/sec and p50 / p95 / p99.
+
+### The two drivers
+
+| Driver | Behavior |
+| --- | --- |
+| `serverless-mysql (managed)` | A module-scoped instance persisting across warm invocations. Reuses a warm connection and, under high `max_connections` utilization, releases it and retries with backoff instead of piling up connections. |
+| `raw mysql2 (per-call)` | Opens a fresh `mysql2` connection per invocation. At concurrency above `max_connections` it fails with `ER_CON_COUNT_ERROR`. |
+
+Both run the identical query (`SELECT SLEEP(...)`) so the comparison is fair —
+the managed driver's latency *includes* the library's management overhead.
+
+## Running it
+
+Requires **Docker** (with the Docker socket available to LocalStack) and **Node 18+**.
+
+```bash
+npm ci                 # installs @aws-sdk/client-lambda + mysql2 (from repo root)
+npm run benchmark      # boot stack -> build -> run -> write results.json / results.md
+```
+
+To also inject the results into the top-level README:
+
+```bash
+npm run benchmark:readme
+```
+
+### Knobs (environment variables)
+
+| Var | Default | Meaning |
+| --- | --- | --- |
+| `CONCURRENCY` | `5,10,20,30` | Comma-separated concurrency levels (kept ≤ LocalStack's reliable ceiling) |
+| `DURATION_MS` | `8000` | Duration per driver/level |
+| `QUERY_SLEEP` | `0.02` | Seconds the query holds the connection |
+| `MAX_CONNECTIONS` | `30` | Recorded in metadata; set to match docker-compose |
+
+`max_connections` itself is set in [`docker-compose.yml`](docker-compose.yml); keep
+the `MAX_CONNECTIONS` env in sync if you change it.
+
+## How it fits together
+
+- [`docker-compose.yml`](docker-compose.yml) — LocalStack + MySQL on a shared network.
+- [`lambda/handler.js`](lambda/handler.js) — the two drivers (`MODE=managed|raw`).
+- [`build.sh`](build.sh) — packages the handler with `mysql2` and the working-tree
+  `serverless-mysql` into `function.zip`.
+- [`bench.js`](bench.js) — deploys both functions to LocalStack, runs the workload,
+  polls connections, writes `results.json` / `results.md`.
+- [`update-readme.js`](update-readme.js) — injects the table into the top-level README.
+- [`run.sh`](run.sh) — orchestrates the whole thing.
+
+## Caveats
+
+LocalStack *emulates* Lambda; container reuse, concurrency limits, and cold-start
+timing differ from real AWS, and Community-edition concurrency is throttled (hence
+the modest default levels). Absolute numbers vary by hardware — treat them as a
+demonstration of the **mechanism and relative behavior**, not production SLAs. The
+only strictly more faithful setup is real AWS Lambda + Aurora.

--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -1,0 +1,245 @@
+'use strict';
+
+// Benchmark driver. Deploys two Lambda functions (managed = serverless-mysql,
+// raw = mysql2 connection-per-call) to LocalStack, then for each concurrency level
+// fires a fixed-duration concurrent workload at each while sampling the database's
+// open-connection count. Emits results.json and results.md.
+//
+// Everything talks to LocalStack over the AWS SDK, so no aws-cli / awslocal needed.
+
+const fs = require('fs');
+const path = require('path');
+const mysql = require('mysql2/promise');
+const {
+  LambdaClient,
+  CreateFunctionCommand,
+  DeleteFunctionCommand,
+  GetFunctionConfigurationCommand,
+  InvokeCommand
+} = require('@aws-sdk/client-lambda');
+const { toMarkdownTable, metaLine } = require('./report');
+
+// ---- Configuration (overridable via env) ----------------------------------
+const ENDPOINT = process.env.AWS_ENDPOINT_URL || 'http://localhost:4566';
+const REGION = 'us-east-1';
+// Capped at 30 by default: LocalStack Community throttles concurrent Lambda
+// containers, and levels at/above ~50 trigger a container-spawn storm that can
+// hang the run. 30 matches the DB's max_connections so the crossover (raw failing
+// once concurrency reaches the cap) is still clearly visible. Override via env.
+const CONCURRENCY_LEVELS = (process.env.CONCURRENCY || '5,10,20,30')
+  .split(',').map((n) => parseInt(n, 10));
+const DURATION_MS = Number(process.env.DURATION_MS || 8000);
+const QUERY_SLEEP = process.env.QUERY_SLEEP || '0.02';
+const MAX_CONNECTIONS = Number(process.env.MAX_CONNECTIONS || 30);
+
+// Hostname the Lambda containers use to reach MySQL on the shared Docker network.
+const DB_HOST_LAMBDA = process.env.DB_HOST_LAMBDA || 'benchmark-mysql';
+// Host-side poller connection (mapped port from docker-compose).
+const POLLER = {
+  host: process.env.DB_HOST || '127.0.0.1',
+  port: Number(process.env.DB_PORT || 3307),
+  user: 'root',
+  password: 'password',
+  database: 'benchmark'
+};
+
+const ZIP_PATH = path.join(__dirname, 'lambda', 'function.zip');
+const FUNCTIONS = [
+  { name: 'bench-managed', mode: 'managed', label: 'serverless-mysql (managed)' },
+  { name: 'bench-raw', mode: 'raw', label: 'raw mysql2 (per-call)' }
+];
+
+const lambda = new LambdaClient({
+  endpoint: ENDPOINT,
+  region: REGION,
+  credentials: { accessKeyId: 'test', secretAccessKey: 'test' }
+});
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ---- Lambda lifecycle ------------------------------------------------------
+async function deployFunctions(zip) {
+  for (const fn of FUNCTIONS) {
+    await lambda.send(new DeleteFunctionCommand({ FunctionName: fn.name })).catch(() => {});
+    await lambda.send(new CreateFunctionCommand({
+      FunctionName: fn.name,
+      Runtime: 'nodejs20.x',
+      Handler: 'handler.handler',
+      Role: 'arn:aws:iam::000000000000:role/lambda-role', // LocalStack ignores validity
+      Code: { ZipFile: zip },
+      Timeout: 30,
+      MemorySize: 256,
+      Environment: {
+        Variables: {
+          MODE: fn.mode,
+          DB_HOST: DB_HOST_LAMBDA,
+          DB_PORT: '3306',
+          DB_NAME: 'benchmark',
+          DB_USER: 'root',
+          DB_PASSWORD: 'password',
+          QUERY_SLEEP: String(QUERY_SLEEP)
+        }
+      }
+    }));
+    await waitActive(fn.name);
+    console.log(`deployed ${fn.name}`);
+  }
+}
+
+async function waitActive(name) {
+  for (let i = 0; i < 60; i++) {
+    const cfg = await lambda.send(new GetFunctionConfigurationCommand({ FunctionName: name }));
+    if (cfg.State === 'Active') return;
+    if (cfg.State === 'Failed') throw new Error(`Lambda ${name} failed: ${cfg.StateReason}`);
+    await sleep(1000);
+  }
+  throw new Error(`Lambda ${name} did not become Active in time`);
+}
+
+async function teardownFunctions() {
+  for (const fn of FUNCTIONS) {
+    await lambda.send(new DeleteFunctionCommand({ FunctionName: fn.name })).catch(() => {});
+  }
+}
+
+async function invokeOnce(name) {
+  try {
+    const res = await lambda.send(new InvokeCommand({
+      FunctionName: name,
+      Payload: Buffer.from('{}')
+    }));
+    const payload = res.Payload ? JSON.parse(Buffer.from(res.Payload).toString('utf8')) : {};
+    if (res.FunctionError || payload.ok === false) {
+      return { ok: false, code: payload.code || res.FunctionError || 'INVOKE_ERROR', ms: payload.ms };
+    }
+    return { ok: true, ms: payload.ms };
+  } catch (err) {
+    return { ok: false, code: err.name || 'SDK_ERROR' };
+  }
+}
+
+// ---- Connection-count poller ----------------------------------------------
+async function startPoller(state) {
+  const conn = await mysql.createConnection(POLLER);
+  let stopped = false;
+  const loop = (async () => {
+    while (!stopped) {
+      try {
+        const [rows] = await conn.query("SHOW STATUS LIKE 'Threads_connected'");
+        const n = Number(rows[0] && rows[0].Value);
+        if (n > state.peak) state.peak = n;
+      } catch (_) { /* transient under load; ignore */ }
+      await sleep(50);
+    }
+  })();
+  return async () => { stopped = true; await loop; await conn.end().catch(() => {}); };
+}
+
+// ---- Stats -----------------------------------------------------------------
+function percentile(sorted, p) {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[idx];
+}
+
+async function runLevel(fn, concurrency) {
+  const state = { peak: 0 };
+  const stopPoller = await startPoller(state);
+
+  const latencies = [];
+  const failures = {};
+  let success = 0;
+  const deadline = Date.now() + DURATION_MS;
+
+  async function worker() {
+    while (Date.now() < deadline) {
+      const r = await invokeOnce(fn.name);
+      if (r.ok) { success++; if (typeof r.ms === 'number') latencies.push(r.ms); }
+      else { failures[r.code] = (failures[r.code] || 0) + 1; }
+    }
+  }
+
+  const startedAt = Date.now();
+  await Promise.all(Array.from({ length: concurrency }, worker));
+  const elapsedSec = (Date.now() - startedAt) / 1000;
+  await stopPoller();
+
+  latencies.sort((a, b) => a - b);
+  const failed = Object.values(failures).reduce((a, b) => a + b, 0);
+  const total = success + failed;
+
+  return {
+    driver: fn.label,
+    mode: fn.mode,
+    concurrency,
+    total,
+    success,
+    failed,
+    successRate: total ? +(100 * success / total).toFixed(1) : 0,
+    failuresByCode: failures,
+    throughput: +(success / elapsedSec).toFixed(1),
+    p50: percentile(latencies, 50),
+    p95: percentile(latencies, 95),
+    p99: percentile(latencies, 99),
+    peakConnections: state.peak
+  };
+}
+
+// ---- Reporting -------------------------------------------------------------
+async function main() {
+  if (!fs.existsSync(ZIP_PATH)) {
+    throw new Error(`Missing ${ZIP_PATH}. Run benchmark/build.sh first.`);
+  }
+  const zip = fs.readFileSync(ZIP_PATH);
+
+  console.log('deploying functions to', ENDPOINT);
+  await deployFunctions(zip);
+
+  const rows = [];
+  try {
+    for (const concurrency of CONCURRENCY_LEVELS) {
+      for (const fn of FUNCTIONS) {
+        process.stdout.write(`running ${fn.mode} @ concurrency ${concurrency} ... `);
+        const result = await runLevel(fn, concurrency);
+        rows.push(result);
+        console.log(`${result.successRate}% ok, ${result.throughput} inv/s, peak ${result.peakConnections} conns`);
+        await sleep(1000); // let warm containers/connections settle between runs
+      }
+    }
+  } finally {
+    await teardownFunctions().catch(() => {});
+  }
+
+  const meta = {
+    generatedAt: new Date().toISOString(),
+    durationMsPerLevel: DURATION_MS,
+    querySleepSeconds: Number(QUERY_SLEEP),
+    maxConnections: MAX_CONNECTIONS,
+    concurrencyLevels: CONCURRENCY_LEVELS,
+    node: process.version
+  };
+
+  const table = toMarkdownTable(rows);
+  fs.writeFileSync(path.join(__dirname, 'results.json'), JSON.stringify({ meta, rows }, null, 2));
+
+  const md = [
+    '# Benchmark Results',
+    '',
+    metaLine(meta),
+    '',
+    table,
+    '',
+    '> Run on a single host via LocalStack Lambda + MySQL in Docker. Numbers illustrate the',
+    '> connection-management mechanism and relative behavior, not absolute production SLAs.',
+    ''
+  ].join('\n');
+  fs.writeFileSync(path.join(__dirname, 'results.md'), md);
+
+  console.log('\n' + table);
+  console.log('\nwrote benchmark/results.json and benchmark/results.md');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/benchmark/build.sh
+++ b/benchmark/build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Bundle the Lambda handler with its dependencies into function.zip.
+# `serverless-mysql` is installed from the parent repo (file:../..) so the
+# benchmark always exercises the working-tree version of the library.
+set -euo pipefail
+
+cd "$(dirname "$0")/lambda"
+
+rm -rf node_modules function.zip
+# --install-links installs the local `serverless-mysql` (file:../..) as a real copy
+# honoring its package `files` field, instead of symlinking the whole repo (which
+# would otherwise pull .git + node_modules into the zip).
+npm install --omit=dev --install-links --no-audit --no-fund
+
+if ! command -v zip >/dev/null 2>&1; then
+  echo "error: 'zip' is required to package the Lambda. Install it and re-run." >&2
+  exit 1
+fi
+
+zip -qr function.zip handler.js node_modules
+echo "Built $(pwd)/function.zip ($(du -h function.zip | cut -f1))"

--- a/benchmark/docker-compose.yml
+++ b/benchmark/docker-compose.yml
@@ -1,0 +1,52 @@
+# Benchmark stack: a real Lambda fleet (LocalStack) against a connection-constrained MySQL.
+# Both services share an explicitly-named network so the Lambda containers LocalStack
+# spawns can reach the database by hostname (benchmark-mysql).
+services:
+  localstack:
+    image: localstack/localstack:3
+    container_name: benchmark-localstack
+    ports:
+      - "4566:4566"
+    environment:
+      SERVICES: lambda
+      # Lambda containers must join the same network as MySQL to resolve `benchmark-mysql`.
+      LAMBDA_DOCKER_NETWORK: serverless-mysql-benchmark-net
+      LAMBDA_RUNTIME_ENVIRONMENT_TIMEOUT: "60"
+      DEBUG: "0"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    networks:
+      - benchmark-net
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:4566/_localstack/health | grep -q '\"lambda\": \"available\"'"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  mysql:
+    image: mysql:lts
+    container_name: benchmark-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: benchmark
+      MYSQL_ROOT_HOST: "%"
+      TZ: UTC
+    ports:
+      # Host-side poller connects on 3307 to avoid clashing with the test DB on 3306.
+      - "3307:3306"
+    # A deliberately low cap so fleet-level connection contention is observable.
+    command: >
+      --max_connections=30
+      --wait_timeout=28800
+    networks:
+      - benchmark-net
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-ppassword"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+networks:
+  benchmark-net:
+    # Fixed name so LAMBDA_DOCKER_NETWORK above matches regardless of compose project dir.
+    name: serverless-mysql-benchmark-net

--- a/benchmark/lambda/handler.js
+++ b/benchmark/lambda/handler.js
@@ -1,0 +1,67 @@
+'use strict';
+
+// One handler, two drivers selected by the MODE env var:
+//
+//   managed -> a module-scoped serverless-mysql instance that PERSISTS across warm
+//              invocations (the real Lambda+RDS pattern). Per call it runs a query and
+//              then calls .end(), which triggers serverless-mysql's connection
+//              management: under high `max_connections` utilization it releases the
+//              connection and retries with backoff instead of piling up connections.
+//
+//   raw     -> a fresh mysql2 connection opened per invocation, queried, and closed.
+//              This is the naive "connection-per-call" model serverless-mysql replaces;
+//              at concurrency above `max_connections` it fails with ER_CON_COUNT_ERROR.
+//
+// Both run the identical query so the comparison is apples-to-apples.
+
+const MODE = process.env.MODE || 'managed';
+const QUERY_SLEEP = Number(process.env.QUERY_SLEEP || 0.02); // seconds of held connection time
+
+const dbConfig = {
+  host: process.env.DB_HOST,
+  port: Number(process.env.DB_PORT || 3306),
+  database: process.env.DB_NAME || 'benchmark',
+  user: process.env.DB_USER || 'root',
+  password: process.env.DB_PASSWORD || 'password',
+  // Keep the failure fast and explicit so the metrics show connection pressure
+  // rather than the harness hanging on a saturated server.
+  connectTimeout: 5000
+};
+
+const mysql2 = require('mysql2/promise');
+
+// Module scope: survives across warm invocations of the same container, which is the
+// whole point of the managed driver. Created lazily on first invocation.
+let managedDb = null;
+function getManagedDb() {
+  if (!managedDb) {
+    managedDb = require('serverless-mysql')({ config: dbConfig });
+  }
+  return managedDb;
+}
+
+exports.handler = async function () {
+  const start = Date.now();
+  try {
+    if (MODE === 'managed') {
+      const db = getManagedDb();
+      await db.query('SELECT SLEEP(?) AS slept', [QUERY_SLEEP]);
+      await db.end(); // runs connection-management logic; does not hard-close warm conns
+    } else {
+      const conn = await mysql2.createConnection(dbConfig);
+      try {
+        await conn.query('SELECT SLEEP(?) AS slept', [QUERY_SLEEP]);
+      } finally {
+        await conn.end();
+      }
+    }
+    return { ok: true, ms: Date.now() - start };
+  } catch (err) {
+    return {
+      ok: false,
+      ms: Date.now() - start,
+      code: err && (err.code || err.name) || 'UNKNOWN',
+      message: err && err.message
+    };
+  }
+};

--- a/benchmark/lambda/package.json
+++ b/benchmark/lambda/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "serverless-mysql-benchmark-lambda",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Lambda handler used by the serverless-mysql benchmark (managed vs raw drivers).",
+  "main": "handler.js",
+  "dependencies": {
+    "mysql2": "^3.12.0",
+    "serverless-mysql": "file:../.."
+  }
+}

--- a/benchmark/report.js
+++ b/benchmark/report.js
@@ -1,0 +1,23 @@
+'use strict';
+
+// Shared formatting so bench.js (results.md) and update-readme.js (README section)
+// always render the same table.
+
+function toMarkdownTable(rows) {
+  const header = '| Driver | Concurrency | Success rate | Throughput (inv/s) | p50 (ms) | p95 (ms) | p99 (ms) | Peak conns | Failures |';
+  const sep = '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |';
+  const body = rows.map((r) => {
+    const fails = r.failed
+      ? Object.entries(r.failuresByCode).map(([c, n]) => `${c}×${n}`).join(', ')
+      : '—';
+    return `| ${r.driver} | ${r.concurrency} | ${r.successRate}% | ${r.throughput} | ${r.p50} | ${r.p95} | ${r.p99} | ${r.peakConnections} | ${fails} |`;
+  }).join('\n');
+  return `${header}\n${sep}\n${body}`;
+}
+
+function metaLine(meta) {
+  return `Generated: ${meta.generatedAt} · MySQL \`max_connections=${meta.maxConnections}\` · ` +
+    `query \`SELECT SLEEP(${meta.querySleepSeconds})\` · ${meta.durationMsPerLevel / 1000}s per level · Node ${meta.node}`;
+}
+
+module.exports = { toMarkdownTable, metaLine };

--- a/benchmark/results.json
+++ b/benchmark/results.json
@@ -1,0 +1,141 @@
+{
+  "meta": {
+    "generatedAt": "2026-06-27T16:37:55.159Z",
+    "durationMsPerLevel": 8000,
+    "querySleepSeconds": 0.02,
+    "maxConnections": 30,
+    "concurrencyLevels": [
+      5,
+      10,
+      20,
+      30
+    ],
+    "node": "v20.19.5"
+  },
+  "rows": [
+    {
+      "driver": "serverless-mysql (managed)",
+      "mode": "managed",
+      "concurrency": 5,
+      "total": 1015,
+      "success": 1015,
+      "failed": 0,
+      "successRate": 100,
+      "failuresByCode": {},
+      "throughput": 126.6,
+      "p50": 22,
+      "p95": 23,
+      "p99": 24,
+      "peakConnections": 6
+    },
+    {
+      "driver": "raw mysql2 (per-call)",
+      "mode": "raw",
+      "concurrency": 5,
+      "total": 1010,
+      "success": 1010,
+      "failed": 0,
+      "successRate": 100,
+      "failuresByCode": {},
+      "throughput": 125.9,
+      "p50": 23,
+      "p95": 25,
+      "p99": 30,
+      "peakConnections": 11
+    },
+    {
+      "driver": "serverless-mysql (managed)",
+      "mode": "managed",
+      "concurrency": 10,
+      "total": 1912,
+      "success": 1912,
+      "failed": 0,
+      "successRate": 100,
+      "failuresByCode": {},
+      "throughput": 238.2,
+      "p50": 22,
+      "p95": 22,
+      "p99": 24,
+      "peakConnections": 11
+    },
+    {
+      "driver": "raw mysql2 (per-call)",
+      "mode": "raw",
+      "concurrency": 10,
+      "total": 1877,
+      "success": 1877,
+      "failed": 0,
+      "successRate": 100,
+      "failuresByCode": {},
+      "throughput": 233.9,
+      "p50": 22,
+      "p95": 25,
+      "p99": 30,
+      "peakConnections": 21
+    },
+    {
+      "driver": "serverless-mysql (managed)",
+      "mode": "managed",
+      "concurrency": 20,
+      "total": 1370,
+      "success": 1370,
+      "failed": 0,
+      "successRate": 100,
+      "failuresByCode": {},
+      "throughput": 170.5,
+      "p50": 22,
+      "p95": 24,
+      "p99": 35,
+      "peakConnections": 21
+    },
+    {
+      "driver": "raw mysql2 (per-call)",
+      "mode": "raw",
+      "concurrency": 20,
+      "total": 1268,
+      "success": 1251,
+      "failed": 17,
+      "successRate": 98.7,
+      "failuresByCode": {
+        "ER_CON_COUNT_ERROR": 17
+      },
+      "throughput": 155.8,
+      "p50": 23,
+      "p95": 28,
+      "p99": 73,
+      "peakConnections": 31
+    },
+    {
+      "driver": "serverless-mysql (managed)",
+      "mode": "managed",
+      "concurrency": 30,
+      "total": 1265,
+      "success": 1265,
+      "failed": 0,
+      "successRate": 100,
+      "failuresByCode": {},
+      "throughput": 157.3,
+      "p50": 22,
+      "p95": 26,
+      "p99": 40,
+      "peakConnections": 27
+    },
+    {
+      "driver": "raw mysql2 (per-call)",
+      "mode": "raw",
+      "concurrency": 30,
+      "total": 1134,
+      "success": 1105,
+      "failed": 29,
+      "successRate": 97.4,
+      "failuresByCode": {
+        "ER_CON_COUNT_ERROR": 29
+      },
+      "throughput": 129.2,
+      "p50": 23,
+      "p95": 29,
+      "p99": 54,
+      "peakConnections": 31
+    }
+  ]
+}

--- a/benchmark/results.md
+++ b/benchmark/results.md
@@ -1,0 +1,17 @@
+# Benchmark Results
+
+Generated: 2026-06-27T16:37:55.159Z · MySQL `max_connections=30` · query `SELECT SLEEP(0.02)` · 8s per level · Node v20.19.5
+
+| Driver | Concurrency | Success rate | Throughput (inv/s) | p50 (ms) | p95 (ms) | p99 (ms) | Peak conns | Failures |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| serverless-mysql (managed) | 5 | 100% | 126.6 | 22 | 23 | 24 | 6 | — |
+| raw mysql2 (per-call) | 5 | 100% | 125.9 | 23 | 25 | 30 | 11 | — |
+| serverless-mysql (managed) | 10 | 100% | 238.2 | 22 | 22 | 24 | 11 | — |
+| raw mysql2 (per-call) | 10 | 100% | 233.9 | 22 | 25 | 30 | 21 | — |
+| serverless-mysql (managed) | 20 | 100% | 170.5 | 22 | 24 | 35 | 21 | — |
+| raw mysql2 (per-call) | 20 | 98.7% | 155.8 | 23 | 28 | 73 | 31 | ER_CON_COUNT_ERROR×17 |
+| serverless-mysql (managed) | 30 | 100% | 157.3 | 22 | 26 | 40 | 27 | — |
+| raw mysql2 (per-call) | 30 | 97.4% | 129.2 | 23 | 29 | 54 | 31 | ER_CON_COUNT_ERROR×29 |
+
+> Run on a single host via LocalStack Lambda + MySQL in Docker. Numbers illustrate the
+> connection-management mechanism and relative behavior, not absolute production SLAs.

--- a/benchmark/run.sh
+++ b/benchmark/run.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Boot the benchmark stack, build the Lambda package, run the benchmark, tear down.
+# Any extra args are forwarded to bench.js (e.g. CONCURRENCY/DURATION_MS via env).
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+cleanup() { docker compose down -v >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "Starting benchmark stack (LocalStack + MySQL)..."
+# --wait blocks until both services report healthy (see healthchecks in compose).
+docker compose up -d --wait
+
+echo "Building Lambda package..."
+./build.sh
+
+echo "Running benchmark..."
+node bench.js "$@"

--- a/benchmark/update-readme.js
+++ b/benchmark/update-readme.js
@@ -1,0 +1,48 @@
+'use strict';
+
+// Injects the latest benchmark results into the README between the
+// <!-- BENCHMARK:START --> / <!-- BENCHMARK:END --> markers. Idempotent.
+// Fails loudly if results.json or the markers are missing rather than guessing.
+
+const fs = require('fs');
+const path = require('path');
+const { toMarkdownTable, metaLine } = require('./report');
+
+const README = path.join(__dirname, '..', 'README.md');
+const RESULTS = path.join(__dirname, 'results.json');
+const START = '<!-- BENCHMARK:START -->';
+const END = '<!-- BENCHMARK:END -->';
+
+function main() {
+  if (!fs.existsSync(RESULTS)) {
+    throw new Error(`Missing ${RESULTS}. Run the benchmark first (npm run benchmark).`);
+  }
+  const { meta, rows } = JSON.parse(fs.readFileSync(RESULTS, 'utf8'));
+  const readme = fs.readFileSync(README, 'utf8');
+
+  const startIdx = readme.indexOf(START);
+  const endIdx = readme.indexOf(END);
+  if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) {
+    throw new Error(`README is missing the ${START} / ${END} markers.`);
+  }
+
+  const section = [
+    START,
+    '',
+    `_${metaLine(meta)}_`,
+    '',
+    toMarkdownTable(rows),
+    '',
+    'See [`benchmark/`](benchmark/) for the harness and methodology. Numbers come from a',
+    'single host (LocalStack Lambda + MySQL in Docker) and illustrate the connection-management',
+    'mechanism and relative behavior, not absolute production SLAs.',
+    '',
+    END
+  ].join('\n');
+
+  const updated = readme.slice(0, startIdx) + section + readme.slice(endIdx + END.length);
+  fs.writeFileSync(README, updated);
+  console.log('README benchmark section updated.');
+}
+
+main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "mysql2": "^3.12.0"
       },
       "devDependencies": {
+        "@aws-sdk/client-lambda": "^3.700.0",
         "chai": "^4.2.0",
         "coveralls": "^3.0.11",
         "eslint": "^8.57.1",
@@ -33,6 +34,526 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/client-lambda": {
+      "version": "3.1075.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1075.0.tgz",
+      "integrity": "sha512-S+sy0L7WEouGGys0kJZJ+br0sQGxgWC+0nR/4ySsym/CSg/k+VHXBdD697WJLli+X5a76tFBshx5bjgVKgLg4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/credential-provider-node": "^3.972.58",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
+      "integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@aws-sdk/xml-builder": "^3.972.31",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.49.tgz",
+      "integrity": "sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.51.tgz",
+      "integrity": "sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.56",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.56.tgz",
+      "integrity": "sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/credential-provider-env": "^3.972.49",
+        "@aws-sdk/credential-provider-http": "^3.972.51",
+        "@aws-sdk/credential-provider-login": "^3.972.55",
+        "@aws-sdk/credential-provider-process": "^3.972.49",
+        "@aws-sdk/credential-provider-sso": "^3.972.55",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.55.tgz",
+      "integrity": "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.58.tgz",
+      "integrity": "sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.49",
+        "@aws-sdk/credential-provider-http": "^3.972.51",
+        "@aws-sdk/credential-provider-ini": "^3.972.56",
+        "@aws-sdk/credential-provider-process": "^3.972.49",
+        "@aws-sdk/credential-provider-sso": "^3.972.55",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.49.tgz",
+      "integrity": "sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.55.tgz",
+      "integrity": "sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/token-providers": "3.1074.0",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.55.tgz",
+      "integrity": "sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.23.tgz",
+      "integrity": "sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+      "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1074.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1074.0.tgz",
+      "integrity": "sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
+      "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
+      "integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -751,6 +1272,198 @@
       "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
       "dev": true
     },
+    "node_modules/@smithy/core": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
+      "integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.2.tgz",
+      "integrity": "sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.2.tgz",
+      "integrity": "sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
+      "integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.2.tgz",
+      "integrity": "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.1.tgz",
@@ -972,6 +1685,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "test-cov": "TZ=UTC nyc --reporter=html mocha --check-leaks --recursive test/{unit,integration}/*.spec.js",
     "test-cov:debug": "TZ=UTC NODE_DEBUG=mysql,net,stream nyc --reporter=html mocha --check-leaks --recursive test/{unit,integration}/*.spec.js",
     "lint": "eslint .",
+    "benchmark": "./benchmark/run.sh",
+    "benchmark:readme": "./benchmark/run.sh && node benchmark/update-readme.js",
     "prepublishOnly": "npm run lint && npm run test:docker"
   },
   "repository": {
@@ -47,6 +49,7 @@
   },
   "homepage": "https://github.com/jeremydaly/serverless-mysql#readme",
   "devDependencies": {
+    "@aws-sdk/client-lambda": "^3.700.0",
     "chai": "^4.2.0",
     "coveralls": "^3.0.11",
     "eslint": "^8.57.1",


### PR DESCRIPTION
Closes #45.

Adds a reproducible benchmark that gives the before/after comparison requested in #45: **serverless-mysql** vs the naive **mysql2 connection-per-call** model, using a *real Lambda fleet* (LocalStack) against a connection-constrained MySQL.

## What it measures

For each concurrency level, a fixed-duration concurrent workload hits each driver while the DB's open-connection count is sampled. Reports success rate (+ failure codes), peak connections, throughput, and p50/p95/p99 latency.

## Committed results

<!-- numbers refreshed automatically on every release -->

| Driver | Concurrency | Success rate | Throughput (inv/s) | Peak conns | Failures |
| --- | ---: | ---: | ---: | ---: | --- |
| serverless-mysql (managed) | 20 | 100% | 170.5 | 21 | — |
| raw mysql2 (per-call) | 20 | 98.7% | 155.8 | 31 | ER_CON_COUNT_ERROR×17 |
| serverless-mysql (managed) | 30 | 100% | 157.3 | 27 | — |
| raw mysql2 (per-call) | 30 | 97.4% | 129.2 | 31 | ER_CON_COUNT_ERROR×29 |

serverless-mysql holds **100% success** while keeping peak connections **under** the `max_connections=30` cap; raw mysql2 saturates the cap and starts failing with `ER_CON_COUNT_ERROR` once concurrency reaches it.

## Contents

- `benchmark/` — docker-compose stack, Lambda handler (`managed`/`raw` drivers), build + driver (deploys via the AWS SDK, runs the workload, polls connections, writes `results.json`/`results.md`).
- `update-readme.js` injects the table into the README between `<!-- BENCHMARK:START/END -->` markers.
- `.github/workflows/release.yml` refreshes the README benchmark section automatically on every tagged release (`v*`).
- npm scripts: `benchmark`, `benchmark:readme`.

## Honest caveats

Run on a single host via LocalStack, which *emulates* Lambda — container reuse/concurrency and cold-start timing differ from real AWS, and Community-edition concurrency is throttled (default levels capped at 30; higher levels can wedge LocalStack). Numbers illustrate the connection-management **mechanism and relative behavior**, not absolute production SLAs. See `benchmark/README.md` for full methodology.

## Test plan

- [x] `npm run lint` passes (benchmark dir is eslint-ignored like `test`/`scripts`)
- [x] `npm run test:unit` passes
- [x] Full benchmark run completes cleanly and produces the committed `results.*`
- [x] README marker injection verified idempotent